### PR TITLE
Update crawlers, fix Yandex/Baidu + add some more

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -146,8 +146,8 @@ static const char *browsers[][2] = {
   /* Crawlers/Bots */
   {"bingbot", "Crawlers"},
   {"msnbot", "Crawlers"},
-  {"Yandex", "Crawlers"},
-  {"Baidu", "Crawlers"},
+  {"YandexBot", "Crawlers"},
+  {"Baiduspider", "Crawlers"},
   {"Ezooms", "Crawlers"},
   {"Twitter", "Crawlers"},
   {"Slurp", "Crawlers"},
@@ -212,7 +212,6 @@ static const char *browsers[][2] = {
   {"TosCrawler", "Crawlers"},
   {"Updownerbot", "Crawlers"},
   {"urlwatch", "Crawlers"},
-  {"IstellaBot", "Crawlers"},
   {"OpenWebSpider", "Crawlers"},
   {"WordPress", "Crawlers"},
   {"yacybot", "Crawlers"},
@@ -256,6 +255,12 @@ static const char *browsers[][2] = {
   {"Image", "Crawlers"},
   {"keybase-proofs", "Crawlers"},
   {"SemrushBot", "Crawlers"},
+  {"CommonCrawler", "Crawlers"},
+  {"Mail.RU_Bot", "Crawlers"},
+  {"MegaIndex.ru", "Crawlers"},
+  {"XoviBot", "Crawlers"},
+  {"X-CAD-SE", "Crawlers"},
+  {"Safeassign", "Crawlers"},
 
   /* Podcast fetchers */
   {"Downcast", "Podcasts"},


### PR DESCRIPTION
Both the Yandex and Baidu spider are not recognized by goaccess. I've also removed IstellaBot (it was in the list twice) and added a few more. Fwiw; here is the full UA of the changed entries based on my 100M access-log (I've only looked at 50K+ entries):

* Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)
* Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/help/robots)
* Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)
* Blackboard Safeassign
* Mozilla/5.0 CommonCrawler Node Z2NYVDPKTTRAML5M6OVRFXUNE6*.cdn0.common.crawl.zone
* Mozilla/5.0 CommonCrawler Node Z2ATPLMYHHDOIEQKOCAV23Q5I6I4*.cdn0.common.crawl.zone
* Mozilla/5.0 CommonCrawler Node Z22ZZPFPIX4GK3DGQ5NF3BE6NOO*.cdn0.common.crawl.zone
* Mozilla/5.0 CommonCrawler Node YZ66R4PTXES6PY2FGNJIMJM2FLJV*.cdn0.common.crawl.zone
* Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +http://megaindex.com/crawler)
* Mozilla/5.0 (compatible; XoviBot/2.0; +http://www.xovibot.net/)
* Mozilla/5.0 (compatible; X-CAD-SE/2.0; +http://info.cadse.easterngraphics.com/wa_contact/) Java/1.8.0_60